### PR TITLE
Docs Proxy and Redirects!

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ $ tox
 python3 -m venv .state/venv
 .state/venv/bin/pip install -r requirements.txt
 export CONVEYOR_ENDPOINT=https://pypi.python.org
+export DOCS_BUCKET=pypi-docs
 .state/venv/bin/gunicorn -k aiohttp.worker.GunicornWebWorker conveyor.app:application
 ```
 

--- a/conveyor/tasks.py
+++ b/conveyor/tasks.py
@@ -1,0 +1,72 @@
+
+import asyncio
+import concurrent.futures
+import json
+
+import botocore
+
+ANON_CONFIG = botocore.client.Config(signature_version=botocore.UNSIGNED)
+
+
+async def fetch_key(s3, bucket, key):
+    resp = await s3.get_object(
+        Bucket=bucket,
+        Key=key,
+    )
+    return resp
+
+
+async def redirects_refresh_task(app):
+    while True:
+        try:
+            try:
+                bucket = app["settings"]["docs_bucket"]
+                session = app["boto.session"]
+                etag = app["redirects"].get('_ETag')
+                async with session.create_client('s3', config=ANON_CONFIG) as s3:
+                    try:
+                        key = await fetch_key(s3, bucket, 'redirects.txt')
+                    except botocore.exceptions.ClientError:
+                        await asyncio.sleep(60)
+                        continue
+                if etag != key['ETag']:
+                    redirects = await key['Body'].read()
+                    redirect_config = {
+                        item['project_name']: {
+                            'include_path': item['include_path'],
+                            'base_uri': item['base_uri'],
+                        }
+                        for item in [json.loads(x) for x in redirects.split(b'\n') if x]
+                    }
+                    redirect_config['_ETag'] = key['ETag']
+                    app["redirects"] = redirect_config
+            except concurrent.futures.CancelledError:
+                raise
+            except Exception as exc:
+                pass
+            await asyncio.sleep(3600)
+        except concurrent.futures.CancelledError:
+            return
+    #sleep = fibo(max_value=10)
+    #while True:
+    #    try:
+    #        result = await token_renewal(url)
+    #        if result:
+    #            sleep_value = min(OPTIONS['token_renew_ttl'],
+    #                              result['auth']['lease_duration']/2)
+    #        else:
+    #            try:
+    #                sleep_value = next(sleep)
+    #            except StopIteration:
+    #                new_token = await retrieve_token(url, OPTIONS['role_name'])
+    #                if new_token is None:
+    #                    sleep = fibo(max_value=10)
+    #                    sleep_value = next(sleep)
+    #                else:
+    #                    clear_token()
+    #                    store_token(new_token['auth']['client_token'])
+    #                    sleep_value = 1
+    #        task_log.info('sleeping %s' % (sleep_value,))
+    #        await asyncio.sleep(sleep_value)
+    #    except concurrent.futures.CancelledError:
+    #        return

--- a/conveyor/views.py
+++ b/conveyor/views.py
@@ -10,13 +10,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import mimetypes
+
 import urllib.parse
 
+import botocore
+
 from aiohttp import web
+
+ANON_CONFIG = botocore.client.Config(signature_version=botocore.UNSIGNED)
 
 
 async def health(request):
     return web.Response(status=200)
+
+
+async def not_found(request):
+    return web.Response(status=404)
 
 
 async def redirect(request):
@@ -91,3 +101,49 @@ async def redirect(request):
     # If we've gotten to this point, it means that we couldn't locate an url
     # to redirect to so we'll jsut 404.
     return web.Response(status=404)
+
+
+async def fetch_key(s3, request, bucket, key):
+    resp = await s3.get_object(
+        Bucket=bucket,
+        Key=key,
+    )
+    return resp
+
+
+async def documentation(request):
+    path = request.match_info["path"]
+    if not path:
+        path = "/"
+    if path.endswith("/"):
+        path += "index.html"
+
+    bucket = request.app["settings"]["docs_bucket"]
+    session = request.app["boto.session"]
+
+    async with session.create_client('s3', config=ANON_CONFIG) as s3:
+        try:
+            key = await fetch_key(s3, request, bucket, path)
+        except botocore.exceptions.ClientError:
+            try:
+                key = await fetch_key(s3, request, bucket, path + "/index.html")
+            except botocore.exceptions.ClientError:
+                return web.Response(status=404)
+            else:
+                return web.HTTPMovedPermanently(location="/" + path + "/")
+
+        content_type, content_encoding = mimetypes.guess_type(path)
+        response = web.StreamResponse(status=200, reason='OK')
+        response.content_type = content_type
+        response.content_encoding = content_encoding
+        body = key['Body']
+        await response.prepare(request)
+        while True:
+            data = await body.read(4096)
+            await response.write(data)
+            await response.drain()
+            if not data:
+                body.close()
+                break
+
+        return response

--- a/conveyor/views.py
+++ b/conveyor/views.py
@@ -112,9 +112,21 @@ async def fetch_key(s3, request, bucket, key):
 
 
 async def documentation(request):
-    path = request.match_info["path"]
-    if not path:
-        path = "/"
+    project_name = request.match_info["project_name"]
+    path = request.match_info.get("path", "")
+
+    if project_name in request.app["redirects"]:
+        location = request.app["redirects"][project_name]["base_uri"]
+        if request.app["redirects"][project_name]["include_path"]:
+            location = f"{location}/{path}"
+        return web.Response(
+            status=302,
+            headers={
+                "Location": location,
+            }
+        )
+
+    path = f"{project_name}/{path}"
     if path.endswith("/"):
         path += "index.html"
 

--- a/requirements.in
+++ b/requirements.in
@@ -1,3 +1,4 @@
+aiobotocore
 aiohttp
 cchardet
 gunicorn

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,13 +4,22 @@
 #
 #    pip-compile --output-file requirements.txt requirements.in
 #
+aiobotocore==0.6.0
 aiohttp==3.0.7
 async-timeout==2.0.0      # via aiohttp
 attrs==17.4.0             # via aiohttp
+botocore==1.8.21          # via aiobotocore
 cchardet==2.1.1
 chardet==3.0.4            # via aiohttp
+docutils==0.14            # via botocore
 gunicorn==19.7.1
 idna-ssl==1.0.1           # via aiohttp
 idna==2.6                 # via idna-ssl, yarl
-multidict==4.1.0          # via aiohttp, yarl
+jmespath==0.9.3           # via botocore
+multidict==4.1.0          # via aiobotocore, aiohttp, yarl
+packaging==17.1           # via aiobotocore
+pyparsing==2.2.0          # via packaging
+python-dateutil==2.7.2    # via botocore
+six==1.11.0               # via packaging, python-dateutil
+wrapt==1.10.11            # via aiobotocore
 yarl==1.1.1               # via aiohttp

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -22,8 +22,11 @@ async def test_session_close():
     async def close():
         pass
 
-    app = {"http.session": pretend.stub(close=close)}
+    app = {
+        "http.session": pretend.stub(close=close),
+        "boto.session": pretend.stub(close=close),
+    }
 
     await session_close(app)
 
-    assert close.calls == [pretend.call()]
+    assert close.calls == [pretend.call(), pretend.call()]


### PR DESCRIPTION
Reimplements the pypi-docs-proxy, also adds the ability to read/parse a `redirects.txt` from the root of the bucket which contains a `\n` joined set of JSON redirect configurations:

```
{"project_name": "clandestined", "include_path": false, "base_uri": "https://ernest.ly"}
{"project_name": "pypi-docs-proxy", "include_path": true, "base_uri": "https://ernest.ly"}
```