### PR TITLE
Add CORS to routes

### DIFF
--- a/conveyor/config.py
+++ b/conveyor/config.py
@@ -125,9 +125,7 @@ def configure():
     # Configure default CORS settings.
     cors = aiohttp_cors.setup(app, defaults={
             "*": aiohttp_cors.ResourceOptions(
-                allow_credentials=True,
-                expose_headers="*",
-                allow_headers="*",
+                allow_methods="GET",
             )
     })
 

--- a/conveyor/config.py
+++ b/conveyor/config.py
@@ -67,27 +67,34 @@ def configure():
 
     app.on_shutdown.append(cancel_tasks)
 
+    # Allow cross-origin GETs by default
+    cors = aiohttp_cors.setup(app, defaults={
+            "*": aiohttp_cors.ResourceOptions(
+                allow_methods="GET",
+            )
+    })
+
     # Add routes and views to our application
-    app.router.add_route(
+    cors.add(app.router.add_route(
         "GET",
         "/packages/{python_version}/{project_l}/{project_name}/{filename}",
         redirect,
-    )
+    ))
     app.router.add_route(
         "HEAD",
         "/packages/{python_version}/{project_l}/{project_name}/{filename}",
         redirect,
     )
-    app.router.add_route(
+    cors.add(app.router.add_route(
         "GET",
         "/packages/{tail:.*}",
         not_found,
-    )
-    app.router.add_route(
+    ))
+    cors.add(app.router.add_route(
         "GET",
         "/packages",
         not_found,
-    )
+    ))
 
     app.router.add_route(
         "GET",
@@ -121,16 +128,5 @@ def configure():
         "/{project_name}",
         documentation_top,
     )
-
-    # Allow cross-origin GETs by default
-    cors = aiohttp_cors.setup(app, defaults={
-            "*": aiohttp_cors.ResourceOptions(
-                allow_methods="GET",
-            )
-    })
-
-    # Add the default CORS configuration to all routes
-    for route in list(app.router.routes()):
-        cors.add(route)
 
     return app

--- a/conveyor/config.py
+++ b/conveyor/config.py
@@ -129,7 +129,7 @@ def configure():
             )
     })
 
-    # Configure CORS on all routes.
+    # Add the default CORS configuration to all routes
     for route in list(app.router.routes()):
         cors.add(route)
 

--- a/conveyor/config.py
+++ b/conveyor/config.py
@@ -122,7 +122,7 @@ def configure():
         documentation_top,
     )
 
-    # Configure default CORS settings.
+    # Allow cross-origin GETs by default
     cors = aiohttp_cors.setup(app, defaults={
             "*": aiohttp_cors.ResourceOptions(
                 allow_methods="GET",

--- a/conveyor/config.py
+++ b/conveyor/config.py
@@ -17,6 +17,7 @@ import aiobotocore
 import aiohttp
 import aiohttp.web
 from aiohttp.web_middlewares import normalize_path_middleware
+import aiohttp_cors
 
 from .views import not_found, redirect, health, documentation, documentation_top, index
 from .tasks import redirects_refresh_task
@@ -120,5 +121,18 @@ def configure():
         "/{project_name}",
         documentation_top,
     )
+
+    # Configure default CORS settings.
+    cors = aiohttp_cors.setup(app, defaults={
+            "*": aiohttp_cors.ResourceOptions(
+                allow_credentials=True,
+                expose_headers="*",
+                allow_headers="*",
+            )
+    })
+
+    # Configure CORS on all routes.
+    for route in list(app.router.routes()):
+        cors.add(route)
 
     return app

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,5 @@
 aiobotocore
 aiohttp
+aiohttp_cors
 cchardet
 gunicorn

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@
 #    pip-compile --output-file requirements.txt requirements.in
 #
 aiobotocore==0.9.2
+aiohttp-cors==0.7.0
 aiohttp==3.3.2
 async-timeout==3.0.0      # via aiohttp
 attrs==18.1.0             # via aiohttp


### PR DESCRIPTION
closes #5. this adds and uses the aiohttp_cors helper package to enable CORS for the routes.