### PR TITLE
Fix allow_methods argument

### DIFF
--- a/conveyor/config.py
+++ b/conveyor/config.py
@@ -69,9 +69,9 @@ def configure():
 
     # Allow cross-origin GETs by default
     cors = aiohttp_cors.setup(app, defaults={
-            "*": aiohttp_cors.ResourceOptions(
-                allow_methods="GET",
-            )
+        "*": aiohttp_cors.ResourceOptions(
+            allow_methods=["GET"],
+        )
     })
 
     # Add routes and views to our application


### PR DESCRIPTION
Currently this raises an exception:

```
[2019-04-24 14:36:39 -0500] [56254] [INFO] Starting gunicorn 19.9.0
[2019-04-24 14:36:39 -0500] [56254] [INFO] Listening at: http://127.0.0.1:8000 (56254)
[2019-04-24 14:36:39 -0500] [56254] [INFO] Using worker: aiohttp.worker.GunicornWebWorker
[2019-04-24 14:36:39 -0500] [56257] [INFO] Booting worker with pid: 56257
[2019-04-24 14:36:39 -0500] [56257] [ERROR] Exception in worker process
Traceback (most recent call last):
  File "/Users/dustiningram/git/pypa/conveyor/.state/venv/lib/python3.7/site-packages/gunicorn/arbiter.py", line 583, in spawn_worker
    worker.init_process()
  File "/Users/dustiningram/git/pypa/conveyor/.state/venv/lib/python3.7/site-packages/aiohttp/worker.py", line 49, in init_process
    super().init_process()
  File "/Users/dustiningram/git/pypa/conveyor/.state/venv/lib/python3.7/site-packages/gunicorn/workers/base.py", line 129, in init_process
    self.load_wsgi()
  File "/Users/dustiningram/git/pypa/conveyor/.state/venv/lib/python3.7/site-packages/gunicorn/workers/base.py", line 138, in load_wsgi
    self.wsgi = self.app.wsgi()
  File "/Users/dustiningram/git/pypa/conveyor/.state/venv/lib/python3.7/site-packages/gunicorn/app/base.py", line 67, in wsgi
    self.callable = self.load()
  File "/Users/dustiningram/git/pypa/conveyor/.state/venv/lib/python3.7/site-packages/gunicorn/app/wsgiapp.py", line 52, in load
    return self.load_wsgiapp()
  File "/Users/dustiningram/git/pypa/conveyor/.state/venv/lib/python3.7/site-packages/gunicorn/app/wsgiapp.py", line 41, in load_wsgiapp
    return util.import_app(self.app_uri)
  File "/Users/dustiningram/git/pypa/conveyor/.state/venv/lib/python3.7/site-packages/gunicorn/util.py", line 350, in import_app
    __import__(module)
  File "/Users/dustiningram/git/pypa/conveyor/conveyor/app.py", line 16, in <module>
    application = configure()
  File "/Users/dustiningram/git/pypa/conveyor/conveyor/config.py", line 73, in configure
    allow_methods="GET",
  File "/Users/dustiningram/git/pypa/conveyor/.state/venv/lib/python3.7/site-packages/aiohttp_cors/resource_options.py", line 133, in __new__
    "got '{!r}'".format(allow_methods))
ValueError: 'allow_methods' must be either '*', or sequence of strings, got ''GET''
```